### PR TITLE
Performance improvements - WIP

### DIFF
--- a/fixtures/a_usage_3.rb
+++ b/fixtures/a_usage_3.rb
@@ -1,4 +1,4 @@
 require_relative "a"
 a = A.new
 a.to_s
-puts a
+a.to_s

--- a/lib/delfos.rb
+++ b/lib/delfos.rb
@@ -8,7 +8,7 @@ module Delfos
     attr_writer :logger, :neo4j, :batch_size, :max_query_size
 
     def setup!(logger: nil, call_site_logger: nil, application_directories: nil,
-               batch_size: nil, max_query_size: nil)
+      batch_size: nil, max_query_size: nil)
       self.logger         = logger         if logger
       self.batch_size     = batch_size     if batch_size
       self.max_query_size = max_query_size if max_query_size
@@ -21,7 +21,7 @@ module Delfos
     end
 
     def max_query_size
-      @max_query_size ||= 10_000
+      @max_query_size ||= 50_000
     end
 
     def include_file?(file)
@@ -56,6 +56,7 @@ module Delfos
 
     def finish!
       flush!
+      call_site_logger.finish!
       Delfos::Neo4j.update_distance!
       disable!
     end

--- a/lib/delfos.rb
+++ b/lib/delfos.rb
@@ -21,7 +21,7 @@ module Delfos
     end
 
     def max_query_size
-      @max_query_size ||= 100_000
+      @max_query_size ||= 10_000
     end
 
     def include_file?(file)

--- a/lib/delfos.rb
+++ b/lib/delfos.rb
@@ -5,17 +5,23 @@ require "delfos/setup"
 module Delfos
   class << self
     attr_accessor :application_directories
-    attr_writer :logger, :neo4j, :batch_size
+    attr_writer :logger, :neo4j, :batch_size, :max_query_size
 
-    def setup!(logger: nil, call_site_logger: nil, application_directories: nil, batch_size: nil)
-      self.logger     = logger     if logger
-      self.batch_size = batch_size if batch_size
+    def setup!(logger: nil, call_site_logger: nil, application_directories: nil,
+               batch_size: nil, max_query_size: nil)
+      self.logger         = logger         if logger
+      self.batch_size     = batch_size     if batch_size
+      self.max_query_size = max_query_size if max_query_size
 
       Delfos::Setup.perform!(call_site_logger: call_site_logger, application_directories: application_directories)
     end
 
     def batch_size
       @batch_size ||= 100
+    end
+
+    def max_query_size
+      @max_query_size ||= 100_000
     end
 
     def include_file?(file)

--- a/lib/delfos.rb
+++ b/lib/delfos.rb
@@ -66,7 +66,9 @@ module Delfos
 
     def default_logger
       require "logger"
-      Logger.new(STDOUT)
+      Logger.new(STDOUT).tap do |l|
+        l.level = Logger::ERROR
+      end
     end
   end
 end

--- a/lib/delfos/method_trace.rb
+++ b/lib/delfos/method_trace.rb
@@ -7,6 +7,8 @@ module Delfos
   module MethodTrace
     class << self
       def trace!
+        @last_returned = nil
+
         on_call.enable
         on_return.enable
       end

--- a/lib/delfos/method_trace/code_location/method.rb
+++ b/lib/delfos/method_trace/code_location/method.rb
@@ -7,7 +7,7 @@ module Delfos
     module CodeLocation
       class Method
         include FilenameHelpers
-        attr_reader :object, :method_name, :line_number, :class_method
+        attr_reader :object, :line_number, :class_method
 
         def initialize(object:, method_name:, file:, line_number:, class_method:)
           @object       = object

--- a/lib/delfos/neo4j/batch/execution.rb
+++ b/lib/delfos/neo4j/batch/execution.rb
@@ -52,7 +52,7 @@ module Delfos
         def check_for_expiry!
           return if @expires.nil? || (@clock.now <= @expires)
 
-          raise QueryExecution::ExpiredTransaction.new(@comit_url, "")
+          raise QueryExecution::ExpiredTransaction.new(@commit_url, "")
         end
 
         def flush_if_required!

--- a/lib/delfos/neo4j/batch/retryable.rb
+++ b/lib/delfos/neo4j/batch/retryable.rb
@@ -76,6 +76,7 @@ module Delfos
 
         def retry_batch!
           Delfos.logger.error do
+            sleep 1 + (retry_count**1.2)
             "Transaction expired - retrying batch. #{queries.count} queries retry_count: #{retry_count}"
           end
 

--- a/lib/delfos/neo4j/batch/retryable.rb
+++ b/lib/delfos/neo4j/batch/retryable.rb
@@ -7,20 +7,28 @@ module Delfos
     module Batch
       class Retryable
         class << self
-          def execute!(query, params: {}, size: nil)
-            ensure_instance(size).execute!(query, params: params)
+          MUTEX = Mutex.new
+
+          def reset!
+            MUTEX.synchronize do
+              Thread.current[:_delfos__retryable_batch] = nil
+            end
           end
 
-          def ensure_instance(size)
-            self.instance ||= new(size: size || 1_000)
+          def ensure_instance(size: nil)
+            MUTEX.synchronize do
+              Thread.current[:_delfos__retryable_batch] ||= new(size: size || 1_000)
+            end
+          end
+
+          def execute!(query, params: {}, size: nil)
+            ensure_instance(size: size).execute!(query, params: params)
           end
 
           def flush!
-            instance&.flush!
-            @instance = nil
+            ensure_instance&.flush!
+            reset!
           end
-
-          attr_accessor :instance
         end
 
         attr_reader :size, :queries, :execution

--- a/lib/delfos/neo4j/call_site_logger.rb
+++ b/lib/delfos/neo4j/call_site_logger.rb
@@ -2,10 +2,23 @@
 
 require_relative "call_stack_query"
 require_relative "call_site_query"
+require_relative "file_system_logger"
 
 module Delfos
   module Neo4j
     class CallSiteLogger
+      def initialize(output_path: nil)
+        @persistence = if output_path
+                         FileSystemLogger.new(output_path: output_path)
+                       else
+                         Neo4j
+        end
+      end
+
+      def finish!
+        @persistence.finish!
+      end
+
       def save_call_stack(call_sites, execution_number)
         perform CallStackQuery, call_sites, execution_number
       end
@@ -19,7 +32,7 @@ module Delfos
       def perform(klass, *args)
         q = klass.new(*args)
 
-        Neo4j.execute(q.query, q.params)
+        @persistence.execute(q.query, q.params)
       end
     end
   end

--- a/lib/delfos/neo4j/call_site_logger.rb
+++ b/lib/delfos/neo4j/call_site_logger.rb
@@ -12,7 +12,7 @@ module Delfos
                          FileSystemLogger.new(output_path: output_path)
                        else
                          Neo4j
-        end
+                       end
       end
 
       def finish!

--- a/lib/delfos/neo4j/file_system_logger.rb
+++ b/lib/delfos/neo4j/file_system_logger.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Delfos
+  module Neo4j
+    class FileSystemLogger
+      def initialize(output_path: nil)
+        @output_path = output_path
+        @count = 0
+      end
+
+      def execute(query, params)
+        file.puts query.gsub("\n", "\\n")
+        file.puts params.to_s.gsub("\n", "\\n")
+        file.puts "\n\n----"
+        @count += 1
+        file.flush if @count % 100 == 0
+      end
+
+      def finish!
+        file.flush
+        file.close
+      end
+
+      private
+
+      def file
+        @file ||= File.open(@output_path, "a")
+      end
+    end
+  end
+end

--- a/lib/delfos/neo4j/file_system_logger.rb
+++ b/lib/delfos/neo4j/file_system_logger.rb
@@ -13,7 +13,7 @@ module Delfos
         file.puts params.to_s.gsub("\n", "\\n")
         file.puts "\n\n----"
         @count += 1
-        file.flush if @count % 100 == 0
+        file.flush if (@count % 100).zero?
       end
 
       def finish!

--- a/lib/delfos/neo4j/query_execution/http_query.rb
+++ b/lib/delfos/neo4j/query_execution/http_query.rb
@@ -16,10 +16,14 @@ module Delfos
           @uri = uri
         end
 
+        def query_length
+          request_body.length
+        end
+
         private
 
         def request_body
-          {
+          @request_body ||= {
             "statements": [{ "statement": formatted_query, "parameters": params }],
           }.to_json
         end

--- a/lib/delfos/neo4j/query_execution/transactional.rb
+++ b/lib/delfos/neo4j/query_execution/transactional.rb
@@ -40,11 +40,11 @@ module Delfos
         private
 
         def transaction_url
-          URI.parse  header("location") if header("location")
+          URI.parse(header("location")) if header("location")
         end
 
         def commit_url
-          URI.parse  json["commit"] if json["commit"]
+          URI.parse(json["commit"]) if json["commit"]
         end
 
         def expires

--- a/lib/delfos/setup.rb
+++ b/lib/delfos/setup.rb
@@ -82,6 +82,9 @@ module Delfos
       Delfos.neo4j                   = nil
     end
 
+    # This method allows resetting in between every spec.  So we avoid load
+    # order issues in cases where we have not run particular specs that require
+    # and define these constants
     def ignoring_undefined(k)
       o = Object.const_get(k)
       yield(o)

--- a/lib/delfos/setup.rb
+++ b/lib/delfos/setup.rb
@@ -77,6 +77,7 @@ module Delfos
       Delfos.logger                  = nil
       Delfos.application_directories = nil
       Delfos.call_site_logger        = nil
+      Delfos.max_query_size          = nil
       @call_site_logger              = nil
       Delfos.neo4j                   = nil
     end

--- a/lib/delfos/setup.rb
+++ b/lib/delfos/setup.rb
@@ -5,9 +5,10 @@ module Delfos
     extend self
     attr_accessor :neo4j
 
-    def perform!(call_site_logger: nil, application_directories: nil)
+    def perform!(call_site_logger: nil, application_directories: nil, query_output_file: nil)
       self.application_directories = application_directories
       self.call_site_logger = call_site_logger
+      self.query_output_file = query_output_file if query_output_file
 
       require "delfos/method_trace"
       ::Delfos::MethodTrace.trace!
@@ -17,6 +18,10 @@ module Delfos
       dirs ||= %w[app lib]
       require "pathname"
       Delfos.application_directories = Array(dirs).map { |f| Pathname.new(f.to_s).expand_path }
+    end
+
+    def query_output_file
+      @query_output_file ||= "./delfos_query_output.cypher"
     end
 
     def call_site_logger
@@ -31,7 +36,7 @@ module Delfos
       Delfos.setup_neo4j!
 
       require "delfos/neo4j/call_site_logger"
-      Delfos:: Neo4j::CallSiteLogger.new
+      Delfos:: Neo4j::CallSiteLogger.new(output_path: query_output_file)
     end
 
     def disable!


### PR DESCRIPTION
Some work towards improving performance. See #26 

It seems that delfos works fine for running a few tests or clicking around a Rails app.
But, it may not be realistic for neo4j to keep up with the volume of data produced during whole test suite runs.
E.g. the `bundler` test suite generates 123M of (uncompressed) queries.
See: https://github.com/ruby-analysis/bundler

I'm sure some work can be done on breaking apart larger queries and getting the correct level of throughput with batching queries etc. 
Of course though, for the use case of looking at coupling in complex applications it isn't necessary at all to push the data live to neo4j. So this branch enables outputting the queries to a file for importing after the fact.

TODO:

- [ ] add tests
- [ ] make configurable in an intuitive way
- [ ] create an importer rake task or binary for importing at a sensible pace
- [ ] ensure the `update_distance` command is executed after the import